### PR TITLE
Add tests for AI news generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # ETLGPT
-## CRIANDO UM PROJETO DE ETL PARA CRM MARKETING UTILIZANDO CHAT GPT ## 
+## CRIANDO UM PROJETO DE ETL PARA CRM MARKETING UTILIZANDO CHAT GPT ##
+
+## Executando os testes
+
+Para rodar os testes unitários utilize o pytest. Caso não possua o pacote instalado, execute:
+
+```bash
+pip install pytest
+```
+
+Depois, basta executar o seguinte comando na raiz do projeto:
+
+```bash
+pytest
+```

--- a/news.py
+++ b/news.py
@@ -1,0 +1,25 @@
+try:
+    import openai
+except ImportError:  # pragma: no cover
+    openai = None
+
+
+def generate_ai_news(user):
+    """Generate marketing news message for the given user."""
+    if openai is None:
+        raise ImportError("openai package is required")
+    completion = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo-16k-0613",
+        messages=[
+            {
+                "role": "system",
+                "content": "Você é um especialista em marketing CRM",
+            },
+            {
+                "role": "user",
+                "content": f"Crie uma Mensagem para {user['name']}, persuadindo ele a comprar em nossa loja (máximo de 100 caracteres)",
+            },
+        ],
+    )
+    return completion.choices[0].message.content.strip('"')
+

--- a/tests/test_generate_ai_news.py
+++ b/tests/test_generate_ai_news.py
@@ -1,0 +1,21 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+
+def test_generate_ai_news_returns_short_string():
+    openai_stub = types.SimpleNamespace()
+    openai_stub.ChatCompletion = Mock()
+    openai_stub.ChatCompletion.create.return_value = Mock(
+        choices=[Mock(message=Mock(content="Mensagem de teste"))]
+    )
+    with patch.dict(sys.modules, {"openai": openai_stub}):
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+        news = importlib.import_module("news")
+        importlib.reload(news)
+        result = news.generate_ai_news({"name": "Joao"})
+        assert isinstance(result, str)
+        assert len(result) <= 100
+


### PR DESCRIPTION
## Summary
- add `generate_ai_news` function in `news.py`
- write unit test with pytest mocking OpenAI
- document how to run tests in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e1232970833288a5075f7b6fb09e