### PR TITLE
Improve README and secure API key usage

### DIFF
--- a/ETLpython.ipynb
+++ b/ETLpython.ipynb
@@ -92,7 +92,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "api_key_gpt = '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'"
+    "import os\n",
+    "api_key_gpt = os.getenv('OPENAI_API_KEY')"
    ]
   },
   {

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ETLGPT
 
+## CRIANDO UM PROJETO DE ETL PARA CRM MARKETING UTILIZANDO CHAT GPT ##
+
 Projeto de ETL para CRM Marketing utilizando ChatGPT.
 
 ## Requisitos

--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
 # ETLGPT
-## CRIANDO UM PROJETO DE ETL PARA CRM MARKETING UTILIZANDO CHAT GPT ## 
+
+Projeto de ETL para CRM Marketing utilizando ChatGPT.
+
+## Requisitos
+- Python 3.9+
+- `pandas`, `requests` e `openai`
+
+## Instalando dependências
+```bash
+pip install pandas requests openai
+```
+
+## Definindo a chave da API da OpenAI
+Obtenha sua chave na plataforma da OpenAI e defina-a em uma variável de ambiente chamada `OPENAI_API_KEY` antes de executar o notebook.
+
+Linux/macOS:
+```bash
+export OPENAI_API_KEY="sua-chave"
+```
+Windows (cmd):
+```cmd
+set OPENAI_API_KEY="sua-chave"
+```
+
+## Executando o notebook
+1. Inicie o Jupyter e abra `ETLpython.ipynb`:
+```bash
+jupyter notebook
+```
+2. Execute as células do notebook na ordem desejada. O arquivo `Extract.csv.txt` deve estar no mesmo diretório.
+
+Também é possível executar o notebook de forma não interativa:
+```bash
+jupyter nbconvert --to notebook --execute ETLpython.ipynb
+```


### PR DESCRIPTION
## Summary
- expand README with setup instructions and OpenAI API key configuration
- load the API key in the notebook from the `OPENAI_API_KEY` environment variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e121b25c8332b8baa514b7c7155d